### PR TITLE
🚀 IAsyncInitializerを実装

### DIFF
--- a/src/NestedDIContainer.Unity/Runtime/IAsyncInitializer.cs
+++ b/src/NestedDIContainer.Unity/Runtime/IAsyncInitializer.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using Cysharp.Threading.Tasks;
+
+namespace NestedDIContainer.Unity.Runtime
+{
+    public interface IAsyncInitializer
+    {
+        UniTask InitializeAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/NestedDIContainer.Unity/Runtime/IAsyncInitializer.cs.meta
+++ b/src/NestedDIContainer.Unity/Runtime/IAsyncInitializer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 237567e4949c401e8c2a19ce97d0d432
+timeCreated: 1739612291

--- a/src/NestedDIContainer.Unity/Runtime/Scopes/MonoBehaviourScopeBase.cs
+++ b/src/NestedDIContainer.Unity/Runtime/Scopes/MonoBehaviourScopeBase.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks.Triggers;
 using TanitakaTech.NestedDIContainer;
 using UnityEngine;
 using IInjectable = TanitakaTech.NestedDIContainer.IInjectable;
@@ -61,9 +62,39 @@ namespace NestedDIContainer.Unity.Runtime.Core
             Inject(this, this);
             IScope scope = this;
             scope.Construct(childBinder, config);
-            scope.Initialize();
 
-            this.GetCancellationTokenOnDestroy().Register(() =>
+            var cancellationTokenOnDestroy = this.GetCancellationTokenOnDestroy();
+            scope.Initialize();
+            if (this is IAsyncInitializer asyncInitializer)
+            {
+                var parentScope = scope;
+                IAsyncInitializer parentAsyncInitializer = null;
+                ProjectScope.Initializers.Add(asyncInitializer);
+
+                while (!parentScope.ParentScopeId.Equals(ProjectScope.Scope.ParentScopeId))
+                {
+                    GlobalProjectScope.Scopes.TryGetValue(parentScope.ParentScopeId.Value, out parentScope);
+                    if (parentScope is IAsyncInitializer parent)
+                    {
+                        parentAsyncInitializer = parent;
+                        break;
+                    }
+                }
+
+                this.StartAsync()
+                    .ContinueWith(async () =>
+                    {
+                        if (parentAsyncInitializer != null)
+                        {
+                            await UniTask.WaitWhile(() => ProjectScope.Initializers.Any(x => x == parentAsyncInitializer), cancellationToken: cancellationTokenOnDestroy);
+                        }
+                        await asyncInitializer.InitializeAsync(cancellationTokenOnDestroy);
+                        ProjectScope.Initializers.Remove(asyncInitializer);
+                    })
+                    .Forget();
+            }
+
+            cancellationTokenOnDestroy.Register(() =>
             {
                 GlobalProjectScope.Scopes.Remove(scopeId);
                 GlobalProjectScope.Modules.RemoveScope(scopeId);

--- a/src/NestedDIContainer.Unity/Runtime/Scopes/MonoBehaviourScopeBase.cs
+++ b/src/NestedDIContainer.Unity/Runtime/Scopes/MonoBehaviourScopeBase.cs
@@ -25,13 +25,11 @@ namespace NestedDIContainer.Unity.Runtime.Core
             Construct(binder, config);
         }
         protected abstract void Construct(DependencyBinder binder, object config);
-        void IScope.Initialize() => Initialize();
-        protected virtual void Initialize() {}
 
         public T Instantiate<T>(T prefab, Transform parent, object config = null) where T : MonoBehaviourScopeBase
         {
             var instance = UnityEngine.Object.Instantiate(prefab, parent);
-            instance.InitializeScope(ScopeId.Create(), ScopeId, config);
+            instance.ConstructScope(ScopeId.Create(), ScopeId, config);
             return instance;
         }
         
@@ -39,11 +37,11 @@ namespace NestedDIContainer.Unity.Runtime.Core
             where TConfig : class
         {
             var instance = UnityEngine.Object.Instantiate(prefab, parent);
-            instance.InitializeScope(ScopeId.Create(), ScopeId, config);
+            instance.ConstructScope(ScopeId.Create(), ScopeId, config);
             return instance;
         }
         
-        internal void InitializeScope(ScopeId scopeId, ScopeId parentScopeId, object config = null, IExtendScope optionExtendScope = null)
+        internal void ConstructScope(ScopeId scopeId, ScopeId parentScopeId, object config = null, IExtendScope optionExtendScope = null)
         {
             ScopeId = scopeId;
             ParentScopeId = parentScopeId;
@@ -64,7 +62,6 @@ namespace NestedDIContainer.Unity.Runtime.Core
             scope.Construct(childBinder, config);
 
             var cancellationTokenOnDestroy = this.GetCancellationTokenOnDestroy();
-            scope.Initialize();
             if (this is IAsyncInitializer asyncInitializer)
             {
                 var parentScope = scope;
@@ -142,7 +139,7 @@ namespace NestedDIContainer.Unity.Runtime.Core
                     var scopeId = ScopeId.Create();
                     if (injectable is MonoBehaviourScopeBase monoBehaviourScope)
                     {
-                        monoBehaviourScope.InitializeScope(scopeId: scopeId, parentScopeId: ScopeId);
+                        monoBehaviourScope.ConstructScope(scopeId: scopeId, parentScopeId: ScopeId);
                         return;
                     }
                     else

--- a/src/NestedDIContainer.Unity/Runtime/Scopes/ProjectScope.cs
+++ b/src/NestedDIContainer.Unity/Runtime/Scopes/ProjectScope.cs
@@ -28,7 +28,7 @@ namespace NestedDIContainer.Unity.Runtime
             }
             _scope = projectScopeReference.CreateProjectScope();
             _scope.ScopeId = ScopeId.Create();
-            _scope.InitializeScope(_scope.ScopeId, ScopeId.Create());
+            _scope.ConstructScope(_scope.ScopeId, ScopeId.Create());
             return _scope;
         }
         

--- a/src/NestedDIContainer.Unity/Runtime/Scopes/ProjectScope.cs
+++ b/src/NestedDIContainer.Unity/Runtime/Scopes/ProjectScope.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using TanitakaTech.NestedDIContainer;
 using UnityEngine;
 
@@ -8,6 +9,8 @@ namespace NestedDIContainer.Unity.Runtime
     {
         internal static ProjectScope Scope => _scope;
         private static ProjectScope _scope;
+
+        internal static List<IAsyncInitializer> Initializers { get; } = new ();
 
         internal static ProjectScope CreateProjectScope()
         {

--- a/src/NestedDIContainer.Unity/Runtime/Scopes/SceneScope.cs
+++ b/src/NestedDIContainer.Unity/Runtime/Scopes/SceneScope.cs
@@ -27,13 +27,11 @@ namespace NestedDIContainer.Unity.Runtime
             var parentScope = ProjectScope.Scope ?? ProjectScope.CreateProjectScope();
             ParentScopeId = ScopeId.Equals(parentScope.ScopeId) ? ScopeId.Create() : parentScope.ScopeId;
 
-            InitializeScope(ScopeId, ParentScopeId.Value, ProjectScope.PopConfig(), new SceneScopeDefaultExtendScope(this));
+            ConstructScope(ScopeId, ParentScopeId.Value, ProjectScope.PopConfig(), new SceneScopeDefaultExtendScope(this));
         }
 
         protected override void Construct(DependencyBinder binder, object config) => Construct(binder, (TConfig)config);
         protected abstract void Construct(DependencyBinder binder, TConfig config);
-        void IScope.Initialize() => Initialize();
-        protected virtual void Initialize() {}
 
         // ISceneLoader implementation -----
         void ISceneScopeLoader.LoadScene<TConfig>(Action loadSceneAction, TConfig config = null) where TConfig : class

--- a/src/NestedDIContainer/Runtime/IScope.cs
+++ b/src/NestedDIContainer/Runtime/IScope.cs
@@ -3,7 +3,6 @@
     public interface IScope
     {
         void Construct(DependencyBinder binder, object config);
-        void Initialize();
         ScopeId ScopeId { get; set; }
         ScopeId? ParentScopeId { get; set; }
     }

--- a/src/NestedDIContainer/Runtime/Scope/Scope.cs
+++ b/src/NestedDIContainer/Runtime/Scope/Scope.cs
@@ -22,7 +22,5 @@
             Construct(binder, (TConfig)config);
         }
         protected abstract void Construct(DependencyBinder dependencyBinder, TConfig config);
-        void IScope.Initialize() => Initialize();
-        protected virtual void Initialize() {}
     }
 }


### PR DESCRIPTION
任意のScopeにIAsyncInitializerをimplementsすることで親スコープの初期化状況を待機した初期化が可能になる

- 親スコープのInitAsyncを待機してから、子スコープのInitAsyncが呼ばれる
- 親の初期化を待ってから子の処理を走らせたい場合などに便利